### PR TITLE
fix: getRootPath方法修改，使其兼容windows系统

### DIFF
--- a/src/typespeed.ts
+++ b/src/typespeed.ts
@@ -75,7 +75,10 @@ function getRootPath(lines: string[]) {
     for (let line of lines) {
         if (line.includes(macths[matchIndex])) {
             if(matchIndex === macths.length - 1) {
-                return line.split("(")[1].split(":")[0];
+                let arr = line.split("(")[1].split(":")
+                arr.pop()
+                arr.pop()
+                return arr.join(':')
             }
             matchIndex++;
         }else{


### PR DESCRIPTION
通过new Error搜索错误堆栈的方法，Mac系统和Windows系统拿到的路径似乎是不一样的，可以采用删除后缀的方式来兼容windows系统